### PR TITLE
fix get body

### DIFF
--- a/src/Glpi/Api/Rest/Client.php
+++ b/src/Glpi/Api/Rest/Client.php
@@ -87,9 +87,10 @@ class Client {
     */
    public function initSessionByCredentials($user, $password) {
       $response = $this->request('get', 'initSession', ['auth' => [$user, $password]]);
+      $body = $response->getBody()->getContents();
       if ($response->getStatusCode() != 200
-         || !$this->sessionToken = json_decode($response->getBody()->getContents(), true)['session_token']) {
-         $body = json_decode($response->getBody()->getContents());
+         || !$this->sessionToken = json_decode($body, true)['session_token']) {
+         $body = json_decode($body);
          throw new Exception(ErrorHandler::getMessage($body[0]));
       }
       return true;
@@ -114,9 +115,10 @@ class Client {
             ],
          ]
       );
+      $body = $response->getBody()->getContents();
       if ($response->getStatusCode() != 200
-         || !$this->sessionToken = json_decode($response->getBody()->getContents(), true)['session_token']) {
-         $body = json_decode($response->getBody()->getContents());
+         || !$this->sessionToken = json_decode($body, true)['session_token']) {
+         $body = json_decode($body);
          throw new Exception(ErrorHandler::getMessage($body[0]));
       }
       return true;

--- a/src/Glpi/Api/Rest/ErrorHandler.php
+++ b/src/Glpi/Api/Rest/ErrorHandler.php
@@ -57,8 +57,9 @@ class ErrorHandler {
       'ERROR_GLPI_DELETE' => "We cannot delete the object to GLPI. This error is not relative to API but to GLPI core. Check the GLPI logs files (in files/_logs directory).",
       'ERROR_GLPI_PARTIAL_DELETE' => "Some of the objects you want to delete triggers an error, maybe a missing field or rights. You'll find with this error, a collection of results.",
       'ERROR_RESOURCE_NOT_FOUND_NOR_COMMONDBTM' => "Resource not found or not an instance of CommonDBTM",
-      'ERROR_APILIB_ARGUMENTS' => "Missing o wrong argument(s) for this function, please check GLPI API and function documentation.",
+      'ERROR_APILIB_ARGUMENTS' => "Missing or wrong argument(s) for this function, please check GLPI API and function documentation.",
       'ERROR_APILIB_ARGS_MANDATORY' => "Missing mandatory param(s) %s.",
+      'ERROR' => 'API on remote GLPI is disabled.',
    ];
 
    /**


### PR DESCRIPTION
```php
$response->getBody()->getContents()
```
cannot be called twice : only the 1st call returns the content, the other calls returns an empty string

Also, in a json encoded error, the index of the error is 1, not 0. 0 is a machine code, 1 is for humans.